### PR TITLE
Added FIELDTYPE keyword to example.conf

### DIFF
--- a/configs/example.conf
+++ b/configs/example.conf
@@ -2,6 +2,9 @@
 # type of input file (currently VASP CHGCAR and Cube files are supported)
 INFILETYPE = VASP
 
+# field type, CHG or POT
+FIELDTYPE = CHG
+
 # path to input file
 INFILE = ./AECCAR
 


### PR DESCRIPTION
Tried to use example.conf to make a new config for a CUBE file. Got a Config::parse error, so I think the example should have the FIELDTYPE keyword explicity stated.